### PR TITLE
Remove deprecated `mediawiki.api.parse` alias

### DIFF
--- a/Mermaid.php
+++ b/Mermaid.php
@@ -53,7 +53,6 @@ class Mermaid {
 			],
 			'dependencies'  => [
 				'mediawiki.api',
-				'mediawiki.api.parse',
 				'ext.mermaid.styles',
 				'ext.mermaid.theme.default',
 				'ext.mermaid.core'


### PR DESCRIPTION
Refs: #21 

Deprecated `mediawiki.api.parse` alias will no longer present in MediaWiki 1.33 and later