### PR TITLE
Add flowchart useMaxWidth config parameter

### DIFF
--- a/src/MermaidParserFunction.php
+++ b/src/MermaidParserFunction.php
@@ -108,7 +108,19 @@ class MermaidParserFunction {
 				}
 
 				if ( $k === 'config.flowchart.curve' ) {
-					$config['flowchart'] = [ 'curve' => $v ];
+					if ( !isset( $config['flowchart'] ) ) {
+						$config['flowchart'] = [];
+					}
+					$config['flowchart']['curve'] = $v;
+					unset( $params[$key] );
+				}
+
+				if ( $k === 'config.flowchart.useMaxWidth' ) {
+					if ( !isset( $config['flowchart'] ) ) {
+						$config['flowchart'] = [];
+					}
+					$config['flowchart']['useMaxWidth'] =
+						filter_var($v, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
 					unset( $params[$key] );
 				}
 			}

--- a/src/MermaidParserFunction.php
+++ b/src/MermaidParserFunction.php
@@ -100,27 +100,26 @@ class MermaidParserFunction {
 		foreach ( $params as $key => $param ) {
 
 			if ( strpos( $param, '=' ) !== false ) {
-				list( $k, $v ) = explode( '=', $param, 2 );
+				list( $k, $value ) = array_map( 'trim', explode( '=', $param, 2 ) );
 
-				if ( $k === 'config.theme' ) {
-					$config['theme'] = $v;
+				$keys = explode( '.', $k );
+				if ( count( $keys ) == 1 || $keys[0] !== 'config' ) {
+					continue;
+				}
+				array_shift( $keys );
+
+				if ( $this->parseParam( $keys, [ 'theme' ], $value, $config ) ) {
 					unset( $params[$key] );
 				}
 
-				if ( $k === 'config.flowchart.curve' ) {
-					if ( !isset( $config['flowchart'] ) ) {
-						$config['flowchart'] = [];
-					}
-					$config['flowchart']['curve'] = $v;
+				elseif ( $this->parseParam( $keys, [ 'flowchart' , 'curve' ], $value,
+					$config ) ) {
 					unset( $params[$key] );
 				}
 
-				if ( $k === 'config.flowchart.useMaxWidth' ) {
-					if ( !isset( $config['flowchart'] ) ) {
-						$config['flowchart'] = [];
-					}
-					$config['flowchart']['useMaxWidth'] =
-						filter_var($v, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+				elseif ( $this->parseParam( $keys, [ 'flowchart', 'useMaxWidth' ],
+						filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
+ 						$config ) ) {
 					unset( $params[$key] );
 				}
 			}
@@ -148,4 +147,21 @@ class MermaidParserFunction {
 		);
 	}
 
+	private function parseParam( $paramKeys, $configKeys, $value, &$config ) {
+
+		if ( $paramKeys !== $configKeys ) {
+			return false;
+		}
+
+		$a = &$config;
+		foreach ( $configKeys as $key ) {
+			if ( !isset( $a[$key] ) ) {
+				$a[$key] = [];
+			}	
+			$a = &$a[$key];
+		}
+		$a = $value;
+
+		return true;
+	}
 }

--- a/tests/phpunit/Unit/MermaidParserFunctionTest.php
+++ b/tests/phpunit/Unit/MermaidParserFunctionTest.php
@@ -104,6 +104,17 @@ class MermaidParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			[ 'A[Hard edge] -->|Link text| B(Round edge)' ],
 			'data-mermaid="{&quot;content&quot;:&quot;A[Hard edge] --&gt;|Link text| B(Round edge)&quot;'
 		];
+
+		yield [
+			[ 'graph LR;', 'config.theme=foo', 'config.flowchart.curve=basis' ],
+			'class="ext-mermaid" data-mermaid="{&quot;content&quot;:&quot;graph LR;&quot;,&quot;config&quot;:{&quot;theme&quot;:&quot;foo&quot;,&quot;flowchart&quot;:{&quot;curve&quot;:&quot;basis&quot;}}}"><div class="mermaid-dots"></div></div>'
+		];
+
+		yield [
+			[ 'graph LR;', 'config.theme=foo', 'config.flowchart.useMaxWidth=false' ],
+			'class="ext-mermaid" data-mermaid="{&quot;content&quot;:&quot;graph LR;&quot;,&quot;config&quot;:{&quot;theme&quot;:&quot;foo&quot;,&quot;flowchart&quot;:{&quot;useMaxWidth&quot;:false}}}"><div class="mermaid-dots"></div></div>'
+		];
+
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #40

This PR addresses adds support for the flowchart useMaxWidth config parameter. It is activated by passing in 'config.flowchart.useMaxWidth=false' to the #mermaid parser function invocation, similar to the current 'config.theme=forest' and 'config.flowchart.curve=basis' parameters.

Scrollbars can be added to the area, if desired, with the following CSS in MediaWiki:Common.css (or elsewhere):
```css
.ext-mermaid > div {
	overflow: scroll;
}
```
In adding the new parameter, the configuration parameter parsing code was also refactored to make it easier to add additional configuration parameters in the future. Also, white space around the equals sign in the parameter was trimmed.

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed

Fixes #
