### PR TITLE
Update documentation for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ have a look at the contribution guideline.
 * [File an issue](https://github.com/SemanticMediaWiki/Mermaid/issues)
 * [Submit a pull request](https://github.com/SemanticMediaWiki/Mermaid/pulls)
 * Ask a question on [the mailing list](https://www.semantic-mediawiki.org/wiki/Mailing_list)
-* Ask a question on the #semantic-mediawiki IRC channel on Freenode.
+
+## For developers
+
+See the documention on how to [update MermaidJS](https://github.com/SemanticMediaWiki/Mermaid/blob/master/docs/
+UPDATEMERMAID.md).
 
 ## Tests
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -51,16 +51,6 @@ parameter can be set to it after invoking the extension, e.g.:
     wfLoadExtension( 'Mermaid' );  
     $mermaidgDefaultTheme = 'neutral';
 
-## Future Updates from MermaidJS
-
-In order to update this repo for future updates, clone this repo and run 
-
-    yarn install
-
-This will pull from the upstream repo and patch the dist js file to load for the mediawiki extension.
-Commit any changes and create a pull request back to the Mermaid extension's repo to put back into the
-composer packages.
-
 [readme]: https://github.com/SemanticMediaWiki/Mermaid/blob/master/README.md
 [release notes]: https://github.com/SemanticMediaWiki/Mermaid/blob/master/docs/RELEASE-NOTES.md
 [usage examples]: https://github.com/SemanticMediaWiki/Mermaid/blob/master/docs/USAGE.md

--- a/docs/UPDATEMERMAID.md
+++ b/docs/UPDATEMERMAID.md
@@ -1,0 +1,13 @@
+Mermaid 3.0.0 indroduced a new mechanism to update the MermaidJS library to be shipped with this
+extension. This document explains how to do it. This document was created for developers only.
+Users need to [install] this extension with whatever version of MermaidJS it was tagged and released.
+
+In order to update this repo for future updates, clone this repo and run 
+
+    yarn install
+
+This will pull from the upstream repo and patch the dist js file to load for the mediawiki extension.
+Commit any changes and create a pull request back to the Mermaid extension's repo to put back into the
+composer packages.
+
+[install]: https://github.com/SemanticMediaWiki/Mermaid/blob/master/README.md


### PR DESCRIPTION
This PR is made in reference to: #60

This PR addresses or contains:
- Moves confusing docu on how to update MermaidJS from the end user installation instructions to a separate file meant for usage by developers only thus making clear that this extension can only be installed with Composer

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes:
