### PR TITLE
Add some text to the loading dots for noscript users

### DIFF
--- a/src/MermaidParserFunction.php
+++ b/src/MermaidParserFunction.php
@@ -100,7 +100,8 @@ class MermaidParserFunction
 				'div',
 				[
 					'class' => 'mermaid-dots',
-				]
+				],
+				"Loading Mermaid graphics... (JavaScript required)"
 			)
 		);
 	}


### PR DESCRIPTION
I have a user that likes to disable Javascript. I know, I know...

However, because the css for the mermaid-dots are loaded via JS... it never displays anything, making it unclear that there's content missing from the page. So, add a little extra content to the mermaid-dots div.

There might be a better solution to get the mermaid-dots css included on pageload, rather than via js callback, but I don't know it.

I'd use <noscript> on the page/template itself if I could, but it seems like mediawiki blocks usage of <noscript> for whatever reason.