### PR TITLE
Passing a string to ParserOutput::addModules()/addModuleStyles() is deprecated

### DIFF
--- a/src/MermaidParserFunction.php
+++ b/src/MermaidParserFunction.php
@@ -74,7 +74,7 @@ class MermaidParserFunction
 
 		// Signal the OutputPageParserOutput hook
 		$parserOutput->setExtensionData('ext-mermaid', true);
-		$parserOutput->addModules('ext.mermaid');
+		$parserOutput->addModules(['ext.mermaid']);
 
 		$graphConfig = [
 			'theme' => $this->config->getDefaultTheme()


### PR DESCRIPTION
This PR is made in reference to: https://phabricator.wikimedia.org/T296123

This PR addresses or contains:
- a simple fix to maintain compatibility with past and future versions
of MediaWiki.
