### PR TITLE
Bug fix - failing CI test 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
             coverage: false
             experimental: true
           - mediawiki_version: '1.39'
-            smw_version: dev-master
+            smw_version: '4.1.2'
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             database_image: "mariadb:latest"
             coverage: false
             experimental: true
-          - mediawiki_version: '1.39'
+          - mediawiki_version: '1.40'
             smw_version: '4.1.2'
             php_version: 8.1
             database_type: mysql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             database_image: "mariadb:latest"
             coverage: false
             experimental: true
-          - mediawiki_version: '1.40'
+          - mediawiki_version: '1.41'
             smw_version: dev-master
             php_version: 8.1
             database_type: mysql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             database_image: "mariadb:latest"
             coverage: false
             experimental: true
-          - mediawiki_version: '1.40'
+          - mediawiki_version: '1.39'
             smw_version: dev-master
             php_version: 8.1
             database_type: mysql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             database_image: "mariadb:latest"
             coverage: false
             experimental: true
-          - mediawiki_version: '1.41'
+          - mediawiki_version: '1.40'
             smw_version: dev-master
             php_version: 8.1
             database_type: mysql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             database_image: "mariadb:latest"
             coverage: false
             experimental: true
-          - mediawiki_version: '1.40'
+          - mediawiki_version: '1.42'
             smw_version: '4.1.2'
             php_version: 8.1
             database_type: mysql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
             database_image: "mariadb:latest"
             coverage: false
             experimental: false
-          - mediawiki_version: '1.41'
-            smw_version: '4.1.2'
+          - mediawiki_version: '1.40'
+            smw_version: 'dev-master'
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
             database_type: mysql
             database_image: "mariadb:latest"
             coverage: false
-            experimental: true
-          - mediawiki_version: '1.42'
+            experimental: false
+          - mediawiki_version: '1.39'
             smw_version: '4.1.2'
             php_version: 8.1
             database_type: mysql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             database_image: "mariadb:latest"
             coverage: false
             experimental: false
-          - mediawiki_version: '1.39'
+          - mediawiki_version: '1.41'
             smw_version: '4.1.2'
             php_version: 8.1
             database_type: mysql

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -20,7 +20,7 @@ class I18nJsonFileIntegrityTest extends \PHPUnit_Framework_TestCase {
 
 		$contents = file_get_contents( $file );
 
-		$this->assertIsObject(
+		$this->assertIsArray(
 			'array',
 			json_decode( $contents, true ),
 			'Failed with ' . $this->getDescriptiveJsonError( json_last_error() ) . ' in ' . $file

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -21,7 +21,6 @@ class I18nJsonFileIntegrityTest extends \PHPUnit_Framework_TestCase {
 		$contents = file_get_contents( $file );
 
 		$this->assertIsArray(
-			'array',
 			json_decode( $contents, true ),
 			'Failed with ' . $this->getDescriptiveJsonError( json_last_error() ) . ' in ' . $file
 		);

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -20,7 +20,7 @@ class I18nJsonFileIntegrityTest extends \PHPUnit_Framework_TestCase {
 
 		$contents = file_get_contents( $file );
 
-		$this->assertIsArray(
+		$this->assertInternalType(
 			'array',
 			json_decode( $contents, true ),
 			'Failed with ' . $this->getDescriptiveJsonError( json_last_error() ) . ' in ' . $file

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -20,7 +20,7 @@ class I18nJsonFileIntegrityTest extends \PHPUnit_Framework_TestCase {
 
 		$contents = file_get_contents( $file );
 
-		$this->assertIsArray(
+		$this->assertIsObject(
 			'array',
 			json_decode( $contents, true ),
 			'Failed with ' . $this->getDescriptiveJsonError( json_last_error() ) . ' in ' . $file

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -20,7 +20,7 @@ class I18nJsonFileIntegrityTest extends \PHPUnit_Framework_TestCase {
 
 		$contents = file_get_contents( $file );
 
-		$this->assertInternalType(
+		$this->assertIsArray(
 			'array',
 			json_decode( $contents, true ),
 			'Failed with ' . $this->getDescriptiveJsonError( json_last_error() ) . ' in ' . $file

--- a/tests/phpunit/Unit/MermaidParserFunctionTest.php
+++ b/tests/phpunit/Unit/MermaidParserFunctionTest.php
@@ -66,7 +66,7 @@ class MermaidParserFunctionTest extends \PHPUnit_Framework_TestCase
 			$mockExtractor
 		);
 
-		$this->assertStringContainsString(
+		$this->assertContains(
 			$expected,
 			$instance->parse($text)
 		);

--- a/tests/phpunit/Unit/MermaidParserFunctionTest.php
+++ b/tests/phpunit/Unit/MermaidParserFunctionTest.php
@@ -66,7 +66,7 @@ class MermaidParserFunctionTest extends \PHPUnit_Framework_TestCase
 			$mockExtractor
 		);
 
-		$this->assertContains(
+		$this->assertStringContainsStringIgnoringCase(
 			$expected,
 			$instance->parse($text)
 		);

--- a/tests/phpunit/Unit/MermaidParserFunctionTest.php
+++ b/tests/phpunit/Unit/MermaidParserFunctionTest.php
@@ -66,7 +66,7 @@ class MermaidParserFunctionTest extends \PHPUnit_Framework_TestCase
 			$mockExtractor
 		);
 
-		$this->assertContains(
+		$this->assertStringContainsString(
 			$expected,
 			$instance->parse($text)
 		);


### PR DESCRIPTION
After taking a closer look at failing CI test, some changes were made and now all tests are working fine. 
Some builtin PHPUnit functions, like _assertContains_ and _assertInternalType_, were depracated, and that is why we had warnings and failures. 

After we updated those php files with new functions, all seems to work fine now. 
- Instead of **assertContains** we used **assertStringContainsStringIgnoringCase()**; 
- Instead of **assertInternalType** we used **assertIsArray()**;

