### PR TITLE
[Fix] Class "Html" not found error that started in mediawiki version 1.44.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.39'
-            smw_version: '5.0.2'
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.39'
-            smw_version: '5.0.2'
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mysql:8"
-            coverage: false
-            experimental: false
+          # - mediawiki_version: '1.39'
+          #   smw_version: '5.0.2'
+          #   php_version: 8.1
+          #   database_type: mysql
+          #   database_image: "mariadb:11.2"
+          #   coverage: false
+          #   experimental: false
+          # - mediawiki_version: '1.39'
+          #   smw_version: '5.0.2'
+          #   php_version: 8.1
+          #   database_type: mysql
+          #   database_image: "mysql:8"
+          #   coverage: false
+          #   experimental: false
           - mediawiki_version: '1.40'
             smw_version: '5.0.2'
             php_version: 8.1

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Requirements for Mermaid 4.x:
 - PHP 7.4 or later
 - MediaWiki 1.39 or later
 
+Mermaid 5.0.3 and later requirements:
+
+- PHP 7.4 or later
+- MediaWiki 1.40 or later
+
 You can use an older version of Mermaid for older versions of MediaWiki and/or PHP.
 
 ## Installation and configuration

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "mediawiki/mermaid",
+	"name": "mediawiki/mermaid-OTTOWiki",
 	"type": "mediawiki-extension",
 	"description": "Provides a parser function to generate diagrams and charts with the help of the mermaid script language",
 	"keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "mediawiki/mermaid-OTTOWiki",
+	"name": "mediawiki/mermaid",
 	"type": "mediawiki-extension",
 	"description": "Provides a parser function to generate diagrams and charts with the help of the mermaid script language",
 	"keywords": [

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -12,8 +12,22 @@ If you do not have a "composer.local.json" file yet, create one and add the foll
 
 ```
 {
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/Octobersama/Mermaid-OTTOWiki.git"
+		},
+	],
 	"require": {
-		"mediawiki/mermaid": "~5.0.2"
+		"mediawiki/mermaid": "~5.0.3",
+	},
+	"extra": {
+		"merge-plugin": {
+			"include": [
+				"extensions/*/composer.json",
+				"skins/*/composer.json"
+			]
+		}
 	}
 }
 ```
@@ -23,13 +37,20 @@ section in your file:
 
     "mediawiki/mermaid": "~5.0.2"
 
+And add the following to the square brackets of "repositories":
+
+    {
+	    "type": "vcs",
+	    "url": "https://github.com/Octobersama/Mermaid-OTTOWiki.git"
+    }
+
 Remember to add a comma to the end of the preceding line in this section.
 
 ### Step 2
 
 Run the following command in your shell:
 
-    php composer.phar update --no-dev
+    composer update --no-dev
 
 ### Step 3
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -15,7 +15,7 @@ If you do not have a "composer.local.json" file yet, create one and add the foll
 	"repositories": [
 		{
 			"type": "vcs",
-			"url": "https://github.com/Octobersama/Mermaid-OTTOWiki.git"
+			"url": "https://github.com/OTTOWiki/Mermaid-OTTOWiki.git"
 		},
 	],
 	"require": {
@@ -35,13 +35,13 @@ If you do not have a "composer.local.json" file yet, create one and add the foll
 If you already have a "composer.local.json" file add the following line to the end of the "require"
 section in your file:
 
-    "mediawiki/mermaid": "~5.0.2"
+    "mediawiki/mermaid": "~5.0.3"
 
 And add the following to the square brackets of "repositories":
 
     {
 	    "type": "vcs",
-	    "url": "https://github.com/Octobersama/Mermaid-OTTOWiki.git"
+	    "url": "https://github.com/OTTOWiki/Mermaid-OTTOWiki.git"
     }
 
 Remember to add a comma to the end of the preceding line in this section.

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,6 +1,14 @@
 This file contains the *release notes* of the **Mermaid** extension. See also the
 [readme], the [installation and configuration information] and [usage examples].
 
+### 5.0.3
+
+Released July 6, 2025.
+
+* Use updated php array writing in magic word registration file.
+* Fixed class "Html" not found error that started in mediawiki version 1.44.0.
+* Mediawiki versions before 1.40 are no longer supported.
+
 ### 5.0.2
 
 Released July 2, 2025.

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Mermaid",
-	"version": "5.0.2",
+	"version": "5.0.3",
 	"author": [
 			"James Hong Kong",
 			"Tyler Gibson"
@@ -10,7 +10,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "parserhook",
 	"requires": {
-		"MediaWiki": ">= 1.39"
+		"MediaWiki": ">= 1.40"
 	},
 	"ExtensionMessagesFiles": {
 		"MermaidMagic": "i18n/extra/Mermaid.magic.php"

--- a/i18n/extra/Mermaid.magic.php
+++ b/i18n/extra/Mermaid.magic.php
@@ -3,11 +3,11 @@
 /**
  * Magic words
  */
-$magicWords = array();
+$magicWords = [];
 
 /**
  * English (English)
  */
-$magicWords['en'] = array(
-	'mermaid' => array( 0, 'mermaid' )
-);
+$magicWords['en'] = [
+	'mermaid' => [ 0, 'mermaid' ]
+];

--- a/src/MermaidParserFunction.php
+++ b/src/MermaidParserFunction.php
@@ -3,7 +3,7 @@
 namespace Mermaid;
 
 use Parser;
-use Html;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 
 /**


### PR DESCRIPTION
This PR is made in reference to: 

This PR addresses or contains:
- Use updated php array writing in magic word registration file
- Modify use Html; to use MediaWiki\Html\Html; (The Html class has been encapsulated by namespace and is no longer supported in the latest stable version of mediawiki1.44.0. But at the same time, mediawiki versions before 1.40 are no longer supported)
- Some corresponding modifications

This PR includes:

- [x] CI build passed (Except for version 1.39)

Fixes :
- Class "Html" not found error that started in mediawiki version 1.44.0