### PR TITLE
Use namespaced Html class if available

### DIFF
--- a/src/MermaidParserFunction.php
+++ b/src/MermaidParserFunction.php
@@ -3,7 +3,6 @@
 namespace Mermaid;
 
 use Parser;
-use Html;
 use MediaWiki\MediaWikiServices;
 
 /**
@@ -81,7 +80,13 @@ class MermaidParserFunction {
 		$content = implode( "|", $mwParams );
 		$graphConfig = array_merge( $graphConfig, $mermaidConfig );
 
-		return Html::rawElement(
+		if ( class_exists( 'MediaWiki\\Html\\Html' ) ) {
+			// MW 1.40+
+			$htmlClass = \MediaWiki\Html\Html::class;
+		} else {
+			$htmlClass = \Html::class;
+		}
+		return $htmlClass::rawElement(
 			'div',
 			[
 				'class' => $class,
@@ -92,7 +97,7 @@ class MermaidParserFunction {
 					]
 				)
 			],
-			Html::rawElement(
+			$htmlClass::rawElement(
 				'div',
 				[
 					'class' => 'mermaid-dots',


### PR DESCRIPTION
This PR is made in reference to: #127

This PR addresses or contains:
- Fix compatibility with MW 1.44 by using the namespaced Html class if it is available.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #127
