### PR TITLE
Update composer.local.json Example To Not Break MediaWiki Installation

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,18 +10,28 @@ The recommended way to install this extension is using [Composer](http://getcomp
     
 If you do not have a "composer.local.json" file yet, create one and add the following content to it:
 
-```
+```json
 {
 	"require": {
 		"mediawiki/mermaid": "~6.0.1"
-	}
+	},
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "extensions/*/composer.json",
+                "skins/*/composer.json"
+            ]
+        }
+    }
 }
 ```
 
 If you already have a "composer.local.json" file add the following line to the end of the "require"
 section in your file:
 
-    "mediawiki/mermaid": "~6.0.1"
+```json
+"mediawiki/mermaid": "~6.0.1"
+```
 
 Remember to add a comma to the end of the preceding line in this section.
 
@@ -29,27 +39,34 @@ Remember to add a comma to the end of the preceding line in this section.
 
 Run the following command in your shell:
 
-    php composer.phar update --no-dev
+```shell
+php composer.phar update --no-dev
+```
 
 ### Step 3
 
 Add the following line to the end of your "LocalSettings.php" file:
 
-    wfLoadExtension( 'Mermaid' );
-
+```php
+wfLoadExtension( 'Mermaid' );
+```
 
 ## Configuration
 
 One configuration parameter is provided allowing to choose the basic theme for rendering diagrams and charts.
 By default the rendering is set to use the `forest` theme:
 
-    $mermaidgDefaultTheme = 'forest';
+```php
+$mermaidgDefaultTheme = 'forest';
+```
 
 If one would like to use one of the other themes provided (`default`, `neutral` or `dark`) the configuration
 parameter can be set to it after invoking the extension, e.g.:
 
-    wfLoadExtension( 'Mermaid' );  
-    $mermaidgDefaultTheme = 'neutral';
+```php
+wfLoadExtension( 'Mermaid' );  
+$mermaidgDefaultTheme = 'neutral';
+```
 
 [readme]: https://github.com/SemanticMediaWiki/Mermaid/blob/master/README.md
 [release notes]: https://github.com/SemanticMediaWiki/Mermaid/blob/master/docs/RELEASE-NOTES.md


### PR DESCRIPTION
Update new `composer.local.json` code block to include `extra` section (as found in the sample file provided by MediaWiki) to not break MediaWiki installation when running `composer update`. Update syntax highlighting to include relevant languages. Having only a `require` section in the `composer.local.json` file will result in the MediaWiki installation breaking after running `composer update`. The wiki will continue to function fine until you try to save an edit/new page and then it generates an internal error because other packages were updated.

This PR is made in reference to: N/A

This PR addresses or contains:
- Fixes to installation docs to prevent `composer update --no-dev` breaking lastest stable MediaWiki installation.

This PR includes:
- N/A

Fixes # N/A
